### PR TITLE
Add left sidebar topic navigation to Blog page

### DIFF
--- a/blogs/blogs.md
+++ b/blogs/blogs.md
@@ -3,126 +3,117 @@ layout: page
 title: Blog
 ---
 
-<div style="background-color: #3A77B7; color: white; padding: 10px; text-align: center; width: 100%; margin: 0 auto 30px;">
-  <h1 style="margin: 5px 0;">Welcome to My Blog</h1>
-</div>
+<div style="display: flex; gap: 24px; align-items: flex-start; margin-top: 20px;">
+  <aside style="min-width: 220px; background-color: #f3f7fb; border: 1px solid #d5e3f2; border-radius: 10px; padding: 16px; position: sticky; top: 20px;">
+    <h3 style="margin-top: 0; color: #2F5C8C;">Explore Topics</h3>
+    <ul style="list-style: none; padding-left: 0; margin: 0; display: grid; gap: 10px;">
+      <li><a href="../aiml" style="display: block; padding: 10px 12px; background: white; border-radius: 6px; text-decoration: none; color: #2F5C8C; border: 1px solid #d5e3f2;">Machine Learning</a></li>
+      <li><a href="sequence_modelling" style="display: block; padding: 10px 12px; background: white; border-radius: 6px; text-decoration: none; color: #2F5C8C; border: 1px solid #d5e3f2;">Deep Learning</a></li>
+      <li><a href="llms" style="display: block; padding: 10px 12px; background: white; border-radius: 6px; text-decoration: none; color: #2F5C8C; border: 1px solid #d5e3f2;">GenAI</a></li>
+    </ul>
+  </aside>
 
-<p style="text-align: center; font-size: 1.2em; color: #333;">
-  Hi there, <br>
-  Thank you for visiting my blog! Here, you'll find notes, insights, and reflections on a variety of topics, curated from different resources, personal experiences, and ongoing learning.<br><br>
-  Feel free to explore the posts below, and I hope you enjoy the journey through the world of knowledge as much as I do!
-</p>
+  <div style="flex: 1; min-width: 0;">
+    <div style="background-color: #3A77B7; color: white; padding: 10px; text-align: center; width: 100%; margin: 0 auto 30px; border-radius: 8px;">
+      <h1 style="margin: 5px 0;">Welcome to My Blog</h1>
+    </div>
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin: 40px 20px;">
+    <p style="text-align: center; font-size: 1.2em; color: #333;">
+      Hi there, <br>
+      Thank you for visiting my blog! Here, you'll find notes, insights, and reflections on a variety of topics, curated from different resources, personal experiences, and ongoing learning.<br><br>
+      Feel free to explore the posts below, and I hope you enjoy the journey through the world of knowledge as much as I do!
+    </p>
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin: 40px 20px;">
-  
-  <!-- Card 1 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Transformer Model</h2>
-    <p>A deep dive into transformer models used in NLP.</p>
-    <a href="transformer" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin: 40px 0;">
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Transformer Model</h2>
+        <p>A deep dive into transformer models used in NLP.</p>
+        <a href="transformer" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-  <!-- Card 2 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">GoF</h2>
-    <p>Summary GoF</p>
-    <a href="gof" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">GoF</h2>
+        <p>Summary GoF</p>
+        <a href="gof" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-  <!-- Card 3 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Large Language Models </h2>
-    <p>GPT</p>
-    <a href="llms" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Large Language Models </h2>
+        <p>GPT</p>
+        <a href="llms" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-   <!-- Card 4 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Generative Adversarial Network</h2>
-    <p>Generative Adversarial Network</p>
-    <a href="gan" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Generative Adversarial Network</h2>
+        <p>Generative Adversarial Network</p>
+        <a href="gan" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-   <!-- Card 5 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Diffusion Model</h2>
-    <p>Diffusion Model</p>
-    <a href="diffusion" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Diffusion Model</h2>
+        <p>Diffusion Model</p>
+        <a href="diffusion" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-   <!-- Card 6 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">RAG</h2>
-    <p> RAG</p>
-    <a href="rag" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
-  
-<!-- Card 7 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Some Pretrained Model</h2>
-    <p> </p>
-    <a href="pretrainedmodels" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
-  
-<!-- Card 8 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Design Problems & Concepts</h2>
-    <p> </p>
-    <a href="designproblems" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
-  <!-- Add more cards as needed -->
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">RAG</h2>
+        <p> RAG</p>
+        <a href="rag" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-  <!-- Card 9 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">NLP Concepts</h2>
-    <p> </p>
-    <a href="nlpconcepts" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Some Pretrained Model</h2>
+        <p> </p>
+        <a href="pretrainedmodels" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-  <!-- Card 10 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Sequence Modelling</h2>
-    <p> </p>
-    <a href="sequence_modelling" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
-  
-  <!-- Card 11 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">GAN</h2>
-    <p> </p>
-    <a href="gan" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Design Problems & Concepts</h2>
+        <p> </p>
+        <a href="designproblems" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-  <!-- Card 12 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Foundational LLMs</h2>
-    <p> </p>
-    <a href="foundationmodels" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
-  
-  <!-- Card 13 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">Kubernetes</h2>
-    <p> </p>
-    <a href="Kubernetes" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">NLP Concepts</h2>
+        <p> </p>
+        <a href="nlpconcepts" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-   <!-- Card 14 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">AI ML Azure Services</h2>
-    <p> </p>
-    <a href="aimlazure" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
-  </div>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Sequence Modelling</h2>
+        <p> </p>
+        <a href="sequence_modelling" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
 
-   <!-- Card 15 -->
-  <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
-    <h2 style="color: #2F5C8C;">AIML Resources</h2>
-    <p>Comprehensive guide to AI and Machine Learning concepts</p>
-    <a href="../aiml" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Explore</a>
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">GAN</h2>
+        <p> </p>
+        <a href="gan" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
+
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Foundational LLMs</h2>
+        <p> </p>
+        <a href="foundationmodels" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
+
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">Kubernetes</h2>
+        <p> </p>
+        <a href="Kubernetes" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
+
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">AI ML Azure Services</h2>
+        <p> </p>
+        <a href="aimlazure" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Read More</a>
+      </div>
+
+      <div style="background-color: #f9f9f9; border-radius: 10px; box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1); padding: 20px; text-align: center;">
+        <h2 style="color: #2F5C8C;">AIML Resources</h2>
+        <p>Comprehensive guide to AI and Machine Learning concepts</p>
+        <a href="../aiml" style="color: white; background-color: #2F5C8C; padding: 10px 20px; border-radius: 5px; text-decoration: none;">Explore</a>
+      </div>
+    </div>
   </div>
-  
-  
- </div>
 </div>


### PR DESCRIPTION
### Motivation
- Provide quick access to major topic categories from the Blog page by adding a persistent left-side navigation so readers can jump to Machine Learning, Deep Learning, and GenAI sections.

### Description
- Reworked `blogs/blogs.md` to a two-column layout with a sticky left `aside` containing three links: `../aiml` (Machine Learning), `sequence_modelling` (Deep Learning), and `llms` (GenAI). 
- Kept all existing blog cards and content intact while cleaning up duplicated container markup and adjusting spacing and styles for the new layout. 
- Styling is inline in the page to match existing look-and-feel and ensure the sidebar is visually distinct and responsive. 
- Changes were committed to the repository (modified file: `blogs/blogs.md`).

### Testing
- Ran `git diff -- blogs/blogs.md` to verify the edits, which reported the expected changes (success). 
- Attempted `bundle exec jekyll build` but it failed due to a missing `Gemfile` in this environment (failure). 
- Generated a local HTML preview and produced a visual screenshot using `python3 -m http.server` plus a Playwright script which created `artifacts/blog-sidebar-preview.png` to validate the layout (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a570945c8333bbb0818142ad0ab5)